### PR TITLE
Update topviewmouse and quadruped modelzoo urls (add new models)

### DIFF
--- a/dlclibrary/dlcmodelzoo/modelzoo_urls_pytorch.yaml
+++ b/dlclibrary/dlcmodelzoo/modelzoo_urls_pytorch.yaml
@@ -17,6 +17,7 @@ superanimal_topviewmouse:
     resnet_50: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_resnet_50.pt
     resnet_101: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_resnet_101.pt
     rtmpose_s: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_rtmpose_s.pt
+    rtmpose_m: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_rtmpose_m.pt
     rtmpose_x: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_rtmpose_x.pt
 
 superanimal_quadruped:
@@ -26,8 +27,12 @@ superanimal_quadruped:
     ssdlite: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_ssdlite.pt
   pose_models:
     hrnet_w32: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_hrnet_w32.pt
+    hrnet_w48: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_hrnet_w48.pt
     resnet_50: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_resnet_50.pt
+    resnet_101: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_resnet_101.pt
     rtmpose_s: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_rtmpose_s.pt
+    rtmpose_m: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_rtmpose_m.pt
+    rtmpose_x: mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/superanimal_quadruped_rtmpose_x.pt
 
 superanimal_humanbody:
   detectors: {}

--- a/dlclibrary/dlcmodelzoo/modelzoo_urls_pytorch.yaml
+++ b/dlclibrary/dlcmodelzoo/modelzoo_urls_pytorch.yaml
@@ -13,7 +13,11 @@ superanimal_topviewmouse:
     fasterrcnn_resnet50_fpn_v2: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_fasterrcnn_resnet50_fpn_v2.pt
   pose_models:
     hrnet_w32: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_hrnet_w32.pt
+    hrnet_w48: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_hrnet_w48.pt
     resnet_50: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_resnet_50.pt
+    resnet_101: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_resnet_101.pt
+    rtmpose_s: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_rtmpose_s.pt
+    rtmpose_x: mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse/superanimal_topviewmouse_rtmpose_x.pt
 
 superanimal_quadruped:
   detectors:


### PR DESCRIPTION
Some models on huggingface (see [topviewmouse ](https://huggingface.co/mwmathis/DeepLabCutModelZoo-SuperAnimal-TopViewMouse) and [quadruped](https://huggingface.co/mwmathis/DeepLabCutModelZoo-SuperAnimal-Quadruped/tree/main) repos) were not included in the list of pytorch modelzoo models.

This PR adds the urls for the models:
- rtmpose_s
- rtmpose_m
- rtmpose_x
- hrnet_w48
- resnet_101